### PR TITLE
Enforce consistent casing in TS

### DIFF
--- a/src/__tests__/http_client.test.ts
+++ b/src/__tests__/http_client.test.ts
@@ -10,7 +10,7 @@ import nock from 'nock';
 import { WAConfigType } from '@/config';
 import { HttpMethodsEnum } from '../types/enums';
 
-import HttpsClient from '../HttpsClient';
+import HttpsClient from '../httpsClient';
 import { NoParamCallback } from 'fs';
 
 describe('HTTPS client tests', () => {

--- a/src/api/messages.ts
+++ b/src/api/messages.ts
@@ -14,7 +14,7 @@ import {
 	MessageTypesEnum,
 	WAConfigEnum,
 } from '../types/enums';
-import { RequestData } from '@/HttpsClient';
+import { RequestData } from '@/httpsClient';
 import * as m from '@/messages';
 import Logger from '../logger';
 

--- a/src/httpsClient.ts
+++ b/src/httpsClient.ts
@@ -15,7 +15,7 @@ import {
 	RequestData,
 	ResponseHeaders,
 	ResponseJSONBody,
-} from '@/HttpsClient';
+} from '@/httpsClient';
 import Logger from './logger';
 import { HttpMethodsEnum } from './types/enums';
 

--- a/src/requester.ts
+++ b/src/requester.ts
@@ -7,7 +7,7 @@
  */
 
 import Logger from './logger';
-import HttpsClient from './HttpsClient';
+import HttpsClient from './httpsClient';
 import { HttpMethodsEnum } from './types/enums';
 import { RequesterClass, GeneralHeaderInterface } from '@/requester';
 

--- a/src/types/requester.d.ts
+++ b/src/types/requester.d.ts
@@ -10,7 +10,7 @@ import {
 	RequestHeaders,
 	HttpsClientResponseClass,
 	ResponseJSONBody,
-} from '@/HttpsClient';
+} from '@/httpsClient';
 import { HttpMethodsEnum } from './enums';
 
 export declare type GeneralRequestBody = Record<string, any>;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -39,7 +39,8 @@
 		"moduleResolution": "node",
 		"isolatedModules": true,
     	"skipLibCheck": false,
-		"resolveJsonModule": true
+		"resolveJsonModule": true,
+		"forceConsistentCasingInFileNames": true,
 	},
 	"include": [ "src/**/*" ],
 	"exclude": [


### PR DESCRIPTION
Enable `forceConsistentCasingInFileNames`, which catches some inconsistencies in module usage.

This is likely an issue on case sensitive file systems today since one of these is real code (not just types). The failing Linux CI jobs are because of this issue, eg https://github.com/WhatsApp/WhatsApp-Nodejs-SDK/actions/runs/4622389949/jobs/8175022864.