### PR TITLE
Update version script for better readability, include ending newline

### DIFF
--- a/scripts/create_version_file.mjs
+++ b/scripts/create_version_file.mjs
@@ -8,9 +8,14 @@
 
 import fs from 'graceful-fs';
 
-const copyright_string =
-	'/**\n * Copyright (c) Meta Platforms, Inc. and affiliates.\n * All rights reserved.\n *\n * This source code is licensed under the license found in the\n * LICENSE file in the root directory of this source tree.\n */\n\n';
+const contents = `/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
-const contents = `${copyright_string}export const SDKVersion = '${process.env.npm_package_version}';`;
-
+export const SDKVersion = '${process.env.npm_package_version}';
+`;
 fs.writeFile('./src/version.ts', contents);


### PR DESCRIPTION
The build script writes to this file, but it doesn't add a newline, so if prettier isn't explicitly run then the file shows up in a dirty state.

Also made the script slightly easier to read by using template strings throughout rather than escaped newlines.

It might be a good idea to do some kind of `@generated` marking in the output to discourage manual editing (and can teach prettier not to make any changes to it)