### PR TITLE
Move dotenv as a dev dependency and use conditional imports.

### DIFF
--- a/babel.config.json
+++ b/babel.config.json
@@ -21,6 +21,7 @@
 	],
 	"plugins": [
 		"add-module-exports",
+		"@babel/plugin-proposal-dynamic-import",
 		[
 			"@babel/plugin-transform-modules-commonjs",
 			{

--- a/package.json
+++ b/package.json
@@ -56,12 +56,12 @@
 	},
 	"homepage": "https://whatsapp.github.io/WhatsApp-Nodejs-SDK/",
 	"dependencies": {
-		"@types/node": "~18.11.18",
-		"dotenv": "~16.0.3"
+		"@types/node": "~18.11.18"
 	},
 	"devDependencies": {
 		"@babel/cli": "^7.21.0",
 		"@babel/core": "^7.21.4",
+		"@babel/plugin-proposal-dynamic-import": "^7.18.6",
 		"@babel/plugin-transform-modules-commonjs": "^7.21.2",
 		"@babel/preset-env": "^7.21.4",
 		"@babel/preset-typescript": "^7.21.4",
@@ -73,6 +73,7 @@
 		"babel-jest": "^29.5.0",
 		"babel-plugin-add-module-exports": "^1.0.4",
 		"cspell": "^6.31.1",
+		"dotenv": "^16.0.3",
 		"eslint": "~8.37.0",
 		"eslint-config-prettier": "~8.8.0",
 		"eslint-plugin-jest": "~27.2.1",

--- a/src/WhatsApp.ts
+++ b/src/WhatsApp.ts
@@ -6,12 +6,11 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import * as dotenv from 'dotenv';
 if (
 	process.env.NODE_ENV !== 'production' ||
 	process.env.TS_NODE_DEV === 'true'
 ) {
-	dotenv.config();
+	import('dotenv').then((dotenv) => dotenv.config());
 }
 
 import { WAConfigType } from './types/config';

--- a/yarn.lock
+++ b/yarn.lock
@@ -2669,7 +2669,7 @@ dot-prop@^5.2.0:
   dependencies:
     is-obj "^2.0.0"
 
-dotenv@~16.0.3:
+dotenv@^16.0.3:
   version "16.0.3"
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.0.3.tgz#115aec42bac5053db3c456db30cc243a5a836a07"
   integrity sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==


### PR DESCRIPTION
This change brings the SDK to have no external dependencies other than the standard typescript types. Also moves dotenv to be any version above the listed if available globally.
